### PR TITLE
Fix passing of arguments in case of check_user #2047

### DIFF
--- a/files/env.sh
+++ b/files/env.sh
@@ -244,7 +244,7 @@ check_user() {
 
         # This will drop privileges into the runner user
         # It exec's in a new shell and the current shell will exit
-        exec su - $RUNNER_USER -s $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT -- "$ESCAPED_ARGS"
+        exec su - $RUNNER_USER -s $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT -- $ESCAPED_ARGS
     fi
 }
 


### PR DESCRIPTION
Check_user forwards all arguments as one, thus changes the behaviour of called scripts that depends on accessing the arguments seperately, e.g. $1 $2

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #2047)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

check_user in env.sh passes all arguments as one (regardless of spaces..). This is different from when the respective script is called without check_user. Subsequently $1, $2... work different depending on which user called the script.  